### PR TITLE
Fixing broken GLM serialization/deserialization

### DIFF
--- a/src/mltk/predictor/glm/GLM.java
+++ b/src/mltk/predictor/glm/GLM.java
@@ -130,7 +130,7 @@ public class GLM implements ProbabilisticClassifier, Regressor {
 	public void read(BufferedReader in) throws Exception {
 		in.readLine();
 		link = LinkFunction.get(in.readLine().split(": ")[1]);
-        in.readLine();
+        	in.readLine();
 		intercept = ArrayUtils.parseDoubleArray(in.readLine());
 		int p = Integer.parseInt(in.readLine().split(": ")[1]);
 		w = new double[intercept.length][p];

--- a/src/mltk/predictor/glm/GLM.java
+++ b/src/mltk/predictor/glm/GLM.java
@@ -130,6 +130,7 @@ public class GLM implements ProbabilisticClassifier, Regressor {
 	public void read(BufferedReader in) throws Exception {
 		in.readLine();
 		link = LinkFunction.get(in.readLine().split(": ")[1]);
+        in.readLine();
 		intercept = ArrayUtils.parseDoubleArray(in.readLine());
 		int p = Integer.parseInt(in.readLine().split(": ")[1]);
 		w = new double[intercept.length][p];
@@ -144,7 +145,7 @@ public class GLM implements ProbabilisticClassifier, Regressor {
 	@Override
 	public void write(PrintWriter out) throws Exception {
 		out.printf("[Predictor: %s]\n", this.getClass().getCanonicalName());
-		out.printf("Link: " + link);
+		out.println("Link: " + link);
 		out.println("Intercept: " + intercept.length);
 		out.println(Arrays.toString(intercept));
 		final int p = w[0].length;
@@ -235,3 +236,4 @@ public class GLM implements ProbabilisticClassifier, Regressor {
 	}
 
 }
+


### PR DESCRIPTION
When attempting to write() and then read() a GLM instance, the following exception is thrown:

java.lang.IllegalArgumentException: Unknown link function: identityIntercept
at mltk.predictor.LinkFunction.get(LinkFunction.java:28)
at mltk.predictor.glm.GLM.read(GLM.java:132)

This PR corrects the format of the output of the write method and modifies the read method accordingly
